### PR TITLE
fix(clone): Escapes target when on win32 cmd shell

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -44,6 +44,10 @@ const maybeShallow = (repo, opts) =>
 
 const isWindows = opts => (opts.fakePlatform || process.platform) === 'win32'
 
+const needsEscaping = (target, opts) => (opts && isWindows(opts) && ('shell' in opts) && opts.shell.match(/cmd/) && target && !target.match(/^"/))
+
+const escapeTarget = (target, opts) => needsEscaping(target, opts) ? ('"' + target + '"') : target
+
 const defaultTarget = (repo, /* istanbul ignore next */ cwd = process.cwd()) =>
   resolve(cwd, basename(repo.replace(/[\/\\]?\.git$/, '')))
 
@@ -92,7 +96,7 @@ const branch = (repo, revDoc, target, opts) => {
     '-b',
     revDoc.ref,
     repo,
-    target,
+    escapeTarget(target, opts),
     '--recurse-submodules',
   ]
   if (maybeShallow(repo, opts))
@@ -107,7 +111,7 @@ const plain = (repo, revDoc, target, opts) => {
   const args = [
     'clone',
     repo,
-    target,
+    escapeTarget(target, opts),
     '--recurse-submodules'
   ]
   if (maybeShallow(repo, opts))
@@ -131,7 +135,7 @@ const unresolved = (repo, ref, target, opts) => {
   // can't do this one shallowly, because the ref isn't advertised
   // but we can avoid checking out the working dir twice, at least
   const lp = isWindows(opts) ? ['--config', 'core.longpaths=true'] : []
-  const cloneArgs = ['clone', '--mirror', '-q', repo, target + '/.git']
+  const cloneArgs = ['clone', '--mirror', '-q', repo, escapeTarget(target + '/.git', opts)]
   const git = (args) => spawn(args, { ...opts, cwd: target })
   return mkdirp(target)
     .then(() => git(cloneArgs.concat(lp)))


### PR DESCRIPTION
Escapes the target on win32 when the shell is set to cmd (be it explicitly on opt.shell or implicitly, by virtue of node being run on a .bat).

Fixes outstanding bugs related to npm install on systems meeting this requirement.